### PR TITLE
Add Presidente page to theme activation and menus

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tema WordPress responsivo para a Agência Reguladora de Serviços Públicos Dele
 ## Instalação Rápida
 1. Copie a pasta do tema para `wp-content/themes/agert`.
 2. No painel do WordPress, ative **AGERT - Tema Oficial**.
-3. Ao ativar, o tema cria automaticamente as páginas **Acervo** e **Participantes**, além do menu "Menu Principal".
+3. Ao ativar, o tema cria automaticamente as páginas **Acervo**, **Sobre a AGERT**, **Presidente** e **Contato**, além do menu "Menu Principal".
 
 Após a ativação você pode personalizar os links do menu em **Aparência > Menus**.
 Caso nenhum menu seja configurado, o tema exibirá um menu inicial com links para Home, Sobre a AGERT, Presidente, Acervo e Contato.

--- a/functions.php
+++ b/functions.php
@@ -396,15 +396,19 @@ if (!function_exists('agert_menu_fallback')) {
                 'is_current' => is_front_page(),
             ],
             [
-                'url'        => agert_get_page_link('acervo'),
-                'label'      => __('Acervo', 'agert'),
-                'is_current' => is_page('acervo') || is_post_type_archive('reuniao') || is_singular('reuniao'),
-            ],
-            [
                 'url'        => agert_get_page_link('sobre-a-agert'),
                 'label'      => __('Sobre a AGERT', 'agert'),
                 'is_current' => is_page(['sobre-a-agert', 'sobre']),
-
+            ],
+            [
+                'url'        => agert_get_page_link('presidente'),
+                'label'      => __('Presidente', 'agert'),
+                'is_current' => is_page('presidente'),
+            ],
+            [
+                'url'        => agert_get_page_link('acervo'),
+                'label'      => __('Acervo', 'agert'),
+                'is_current' => is_page('acervo') || is_post_type_archive('reuniao') || is_singular('reuniao'),
             ],
             [
                 'url'        => agert_get_page_link('contato'),

--- a/inc/activation.php
+++ b/inc/activation.php
@@ -15,19 +15,23 @@ if (!defined('ABSPATH')) {
 function agert_create_pages() {
     $pages = array(
         'acervo' => array(
-            'title'   => 'Acervo',
-            'content' => '<p>Consulte reuniões, anexos e vídeos.</p>',
+            'title'    => 'Acervo',
+            'content'  => '<p>Consulte reuniões, anexos e vídeos.</p>',
             'template' => 'page-acervo.php',
-
         ),
-        'sobre' => array(
-            'title'   => 'Sobre a AGERT',
-            'content' => '<p>Página institucional.</p>',
-            'template' => 'page-sobre.php',
+        'sobre-a-agert' => array(
+            'title'    => 'Sobre a AGERT',
+            'content'  => '<p>Página institucional.</p>',
+            'template' => 'page-sobre-agert.php',
+        ),
+        'presidente' => array(
+            'title'    => 'Presidente',
+            'content'  => '<p>Conheça o presidente da AGERT.</p>',
+            'template' => 'page-presidente.php',
         ),
         'contato' => array(
-            'title'   => 'Contato',
-            'content' => '<p>Fale conosco.</p>',
+            'title'    => 'Contato',
+            'content'  => '<p>Fale conosco.</p>',
             'template' => 'page-contato.php',
         ),
     );
@@ -74,7 +78,7 @@ function agert_create_menu() {
         ));
 
         // Pages
-        foreach (array('acervo', 'sobre', 'contato') as $slug) {
+        foreach (array('sobre-a-agert', 'presidente', 'acervo', 'contato') as $slug) {
             $page = get_page_by_path($slug);
             if ($page) {
                 wp_update_nav_menu_item($menu_id, 0, array(


### PR DESCRIPTION
## Summary
- ensure theme creates Presidente page and adds it to navigation menus
- document automatic creation of Sobre a AGERT, Presidente and Contato pages

## Testing
- `php -l inc/activation.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72a972d54832680500534d67fb0b0