### PR TITLE
Make contact address card full width

### DIFF
--- a/page-contato.php
+++ b/page-contato.php
@@ -106,7 +106,7 @@ $contact_map_url = get_option(
                     'icon'         => 'bi-geo-alt',
                     'label'        => __('Endereço', 'agert'),
                     'text'         => $contact_address,
-                    'wrap_classes' => 'col-12 col-md-8 mx-auto'
+                    'wrap_classes' => 'col-12'
                 )); ?>
             </div>
         </div>


### PR DESCRIPTION
## Summary
- Ensure the contact page address card spans full width of its container

## Testing
- `php -l page-contato.php`
- `php -l template-parts/contato/card-info.php`


------
https://chatgpt.com/codex/tasks/task_e_68a72add44488326929a8991a9ba19bc