### PR TITLE
Align back button with breadcrumb

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -484,14 +484,15 @@ function agert_get_page_link($slug) {
  * Exibe um botão para voltar à página anterior.
  */
 function agert_back_button() {
-    echo '<div class="mb-3"><a href="' . esc_url(wp_get_referer() ?: home_url('/')) . '" class="btn btn-outline-brand btn-sm" aria-label="' . esc_attr__('Voltar', 'agert') . '" title="' . esc_attr__('Voltar', 'agert') . '"><i class="bi bi-arrow-left"></i> ' . esc_html__('Voltar', 'agert') . '</a></div>';
+    $url = esc_url(wp_get_referer() ?: home_url('/'));
+    echo '<a href="' . $url . '" onclick="history.back(); return false;" class="btn btn-outline-brand btn-sm me-3" aria-label="' . esc_attr__('Voltar', 'agert') . '" title="' . esc_attr__('Voltar', 'agert') . '"><i class="bi bi-arrow-left"></i> ' . esc_html__('Voltar', 'agert') . '</a>';
 }
 
 /**
  * Exibe breadcrumbs simples com a página atual.
  */
 function agert_breadcrumb() {
-    echo '<nav aria-label="breadcrumb"><ol class="breadcrumb mb-4">';
+    echo '<nav aria-label="breadcrumb"><ol class="breadcrumb mb-0">';
     echo '<li class="breadcrumb-item"><a href="' . esc_url(home_url('/')) . '">' . esc_html__('Home', 'agert') . '</a></li>';
     if (is_page()) {
         echo '<li class="breadcrumb-item active" aria-current="page">' . esc_html(get_the_title()) . '</li>';

--- a/page-acervo.php
+++ b/page-acervo.php
@@ -10,8 +10,10 @@ get_header();
 
 <div class="container py-5 page-acervo">
     <?php agert_show_status_message(); ?>
-    <?php agert_back_button(); ?>
-    <?php agert_breadcrumb(); ?>
+    <div class="d-flex align-items-center mb-4">
+        <?php agert_back_button(); ?>
+        <?php agert_breadcrumb(); ?>
+    </div>
     <h1 class="mb-4"><?php _e('Acervo', 'agert'); ?></h1>
 
     <nav class="tabbar mb-4" aria-label="<?php esc_attr_e('Seções do acervo', 'agert'); ?>">

--- a/page-contato.php
+++ b/page-contato.php
@@ -48,8 +48,10 @@ $contact_map_url = get_option(
 ?>
 
 <div class="container py-5">
-    <?php agert_back_button(); ?>
-    <?php agert_breadcrumb(); ?>
+    <div class="d-flex align-items-center mb-4">
+        <?php agert_back_button(); ?>
+        <?php agert_breadcrumb(); ?>
+    </div>
     <h1 class="mb-4"><?php the_title(); ?></h1>
 
     <?php if ($success_message) : ?>

--- a/page-presidente.php
+++ b/page-presidente.php
@@ -38,8 +38,10 @@ if (have_posts()) :
         $has_details = $bio_breve || !empty($experiencias) || !empty($formacoes) || $mensagem || $assinatura_nome || $assinatura_cargo;
 ?>
 <div class="container-lg py-5">
-    <?php agert_back_button(); ?>
-    <?php agert_breadcrumb(); ?>
+    <div class="d-flex align-items-center mb-4">
+        <?php agert_back_button(); ?>
+        <?php agert_breadcrumb(); ?>
+    </div>
     <h1 class="text-center mb-5"><?php _e('Presidente', 'agert'); ?></h1>
     <div class="row g-4">
         <?php if ($has_profile) : ?>

--- a/page-sobre-abert.php
+++ b/page-sobre-abert.php
@@ -32,8 +32,10 @@ if (have_posts()) :
 
         <div class="page-sobre py-5">
             <div class="container-lg">
-                <?php agert_back_button(); ?>
-                <?php agert_breadcrumb(); ?>
+                <div class="d-flex align-items-center mb-4">
+                    <?php agert_back_button(); ?>
+                    <?php agert_breadcrumb(); ?>
+                </div>
                 <h1 class="text-center mb-4"><?php echo esc_html($titulo); ?></h1>
 
                 <?php

--- a/page-sobre-agert.php
+++ b/page-sobre-agert.php
@@ -43,8 +43,10 @@ if (have_posts()) :
         }
 ?>
 <div class="container py-5 page-sobre-agert">
-    <?php agert_back_button(); ?>
-    <?php agert_breadcrumb(); ?>
+    <div class="d-flex align-items-center mb-4">
+        <?php agert_back_button(); ?>
+        <?php agert_breadcrumb(); ?>
+    </div>
     <h1 class="mb-4 text-center"><?php the_title(); ?></h1>
 
     <?php if ($content) : ?>

--- a/page-sobre.php
+++ b/page-sobre.php
@@ -34,8 +34,10 @@ if (have_posts()) :
 
         <div class="page-sobre py-5">
             <div class="container-lg">
-                <?php agert_back_button(); ?>
-                <?php agert_breadcrumb(); ?>
+                <div class="d-flex align-items-center mb-4">
+                    <?php agert_back_button(); ?>
+                    <?php agert_breadcrumb(); ?>
+                </div>
                 <h1 class="text-center mb-4"><?php echo esc_html($titulo); ?></h1>
 
                 <?php if (!empty($texto)) : ?>


### PR DESCRIPTION
## Summary
- make back button use browser history and remove extra wrapper
- wrap back button with breadcrumb for horizontal alignment across pages

## Testing
- `php -l functions.php`
- `php -l page-acervo.php`
- `php -l page-contato.php`
- `php -l page-sobre-agert.php`
- `php -l page-sobre-abert.php`
- `php -l page-presidente.php`
- `php -l page-sobre.php`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a72dabd7108326829569f9d1d28dd1