### PR TITLE
Corrige listagens de documentos e vídeos no acervo

### DIFF
--- a/inc/reunioes-helpers.php
+++ b/inc/reunioes-helpers.php
@@ -51,6 +51,50 @@ function agert_bytes_to_human(int $bytes): string {
 }
 
 /**
+ * Detecta a plataforma de vídeo a partir da URL.
+ */
+function agert_detectar_plataforma_video(string $url): string {
+    if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
+        return 'youtube';
+    }
+    if (strpos($url, 'vimeo.com') !== false) {
+        return 'vimeo';
+    }
+    return 'outro';
+}
+
+/**
+ * Extrai o ID de um vídeo do YouTube.
+ */
+function agert_extrair_youtube_id(string $url): string {
+    if (preg_match('/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/', $url, $matches)) {
+        return $matches[1];
+    }
+    return '';
+}
+
+/**
+ * Retorna a URL da thumbnail do YouTube.
+ */
+function agert_thumbnail_youtube(string $id): string {
+    return "https://img.youtube.com/vi/{$id}/maxresdefault.jpg";
+}
+
+/**
+ * Obtém a thumbnail do Vimeo via oEmbed.
+ */
+function agert_thumbnail_vimeo(string $url): string {
+    $response = wp_remote_get('https://vimeo.com/api/oembed.json?url=' . rawurlencode($url));
+    if (!is_wp_error($response)) {
+        $data = json_decode(wp_remote_retrieve_body($response));
+        if (!empty($data->thumbnail_url)) {
+            return $data->thumbnail_url;
+        }
+    }
+    return '';
+}
+
+/**
  * Retorna o ano de uma string datetime.
  */
 function agert_get_year_from_datetime(string $dt): int {
@@ -62,8 +106,6 @@ function agert_get_year_from_datetime(string $dt): int {
  * Conta documentos relacionados à reunião.
  */
 function agert_count_documentos(int $post_id): int {
-    $docs = get_post_meta($post_id, 'anexos', true);
-
     $docs = get_posts(array(
         'post_type'      => 'anexo',
         'post_status'    => 'publish',
@@ -88,6 +130,7 @@ function agert_reuniao_has_video(int $post_id): bool {
         'fields'         => 'ids',
         'posts_per_page' => 1,
     ));
+
     return !empty($videos);
 }
 

--- a/page-acervo.php
+++ b/page-acervo.php
@@ -27,23 +27,6 @@ get_header();
         $selected_year = (int) $years[0];
     }
 
-    $meeting_ids_year = array();
-    if ($selected_year) {
-        $meeting_ids_year = get_posts(array(
-            'post_type'      => 'reuniao',
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-            'fields'         => 'ids',
-            'meta_query'     => array(
-                array(
-                    'key'     => 'data_hora',
-                    'value'   => array($selected_year . '-01-01', $selected_year . '-12-31 23:59:59'),
-                    'compare' => 'BETWEEN',
-                    'type'    => 'DATETIME',
-                ),
-            ),
-        ));
-    }
     if ($years) :
     ?>
         <div class="d-flex justify-content-center gap-2 mb-4" aria-label="<?php esc_attr_e('Filtrar por ano', 'agert'); ?>">
@@ -181,19 +164,25 @@ get_header();
             $doc_search = isset($_GET['doc_q']) ? sanitize_text_field($_GET['doc_q']) : '';
             $doc_args   = array(
                 'post_type'      => 'anexo',
+                'post_status'    => 'publish',
                 'posts_per_page' => 9,
                 'paged'          => $docs_paged,
-                'post_status'    => 'publish',
                 'orderby'        => 'date',
                 'order'          => 'DESC',
                 's'              => $doc_search,
+                'meta_query'     => array(
+                    array(
+                        'key'     => '_arquivo_id',
+                        'compare' => 'EXISTS',
+                    ),
+                ),
             );
 
-            if (!empty($meeting_ids_year)) {
-                $doc_args['meta_query'][] = array(
-                    'key'     => '_reuniao_id',
-                    'value'   => $meeting_ids_year,
-                    'compare' => 'IN',
+            if ($selected_year) {
+                $doc_args['date_query'] = array(
+                    array(
+                        'year' => $selected_year,
+                    ),
                 );
             }
 
@@ -217,23 +206,30 @@ get_header();
             <?php
 
             if ($attachments->have_posts()) {
-                echo '<div class="document-list">';
+                echo '<div class="row row-cols-1 row-cols-md-3 g-4">';
                 while ($attachments->have_posts()) : $attachments->the_post();
-                    $reuniao_id = get_post_meta(get_the_ID(), '_reuniao_id', true);
-                    $meeting    = $reuniao_id ? get_post($reuniao_id) : null;
-                    if ($selected_year && $meeting) {
-                        $m_date = agert_meta($meeting->ID, 'data_hora');
-                        if ($m_date && (int) date('Y', strtotime($m_date)) !== $selected_year) {
-                            continue;
-                        }
+                    $arquivo_id  = (int) get_post_meta(get_the_ID(), '_arquivo_id', true);
+                    if (!$arquivo_id) { continue; }
+                    $file_url   = wp_get_attachment_url($arquivo_id);
+                    $file_path  = get_attached_file($arquivo_id);
+                    $file_size  = ($file_path && file_exists($file_path)) ? size_format(filesize($file_path)) : '';
+                    $thumb      = wp_get_attachment_image($arquivo_id, 'thumbnail', true);
+                    $upload_date = get_the_date('d/m/Y');
+                    echo '<div class="col">';
+                    echo '<div class="documento-card">';
+                    if ($thumb) {
+                        echo '<div class="documento-icon">' . $thumb . '</div>';
+                    } else {
+                        echo '<div class="documento-icon">📄</div>';
                     }
-                    $arquivo_id = (int) get_post_meta(get_the_ID(), '_arquivo_id', true);
-                    $doc        = array(
-                        'rotulo'      => get_the_title(),
-                        'resumo'      => get_the_excerpt(),
-                        'arquivo_url' => $arquivo_id ? wp_get_attachment_url($arquivo_id) : '',
-                    );
-                    get_template_part('parts/reunioes/row-documento', null, array('doc' => $doc, 'meeting' => $meeting));
+                    echo '<div class="documento-info">';
+                    echo '<h3>' . esc_html(get_the_title()) . '</h3>';
+                    echo '<p>' . sprintf(__('Enviado em: %s', 'agert'), esc_html($upload_date)) . '</p>';
+                    if ($file_size) {
+                        echo '<p>' . sprintf(__('Tamanho: %s', 'agert'), esc_html($file_size)) . '</p>';
+                    }
+                    echo '<a href="' . esc_url($file_url) . '" class="btn-download btn btn-brand" download><i class="icon-download"></i> ' . __('Download', 'agert') . '</a>';
+                    echo '</div></div></div>';
                 endwhile;
                 echo '</div>';
 
@@ -276,14 +272,43 @@ get_header();
                 's'              => $video_search,
                 'orderby'        => 'date',
                 'order'          => 'DESC',
+                'meta_query'     => array(
+                    array(
+                        'key'     => 'video_url',
+                        'value'   => '',
+                        'compare' => '!=',
+                    ),
+                ),
             );
 
-            if (!empty($meeting_ids_year)) {
-                $video_args['meta_query'][] = array(
-                    'key'     => 'reuniao_relacionada',
-                    'value'   => $meeting_ids_year,
-                    'compare' => 'IN',
-                );
+            if ($selected_year) {
+                $reunioes_ids = get_posts(array(
+                    'post_type'      => 'reuniao',
+                    'post_status'    => 'publish',
+                    'fields'         => 'ids',
+                    'posts_per_page' => -1,
+                    'meta_query'     => array(
+                        array(
+                            'key'     => 'data_hora',
+                            'value'   => array($selected_year . '-01-01', $selected_year . '-12-31 23:59:59'),
+                            'compare' => 'BETWEEN',
+                            'type'    => 'DATETIME',
+                        ),
+                    ),
+                ));
+                if ($reunioes_ids) {
+                    $video_args['meta_query'][] = array(
+                        'key'     => 'reuniao_relacionada',
+                        'value'   => $reunioes_ids,
+                        'compare' => 'IN',
+                    );
+                } else {
+                    $video_args['meta_query'][] = array(
+                        'key'     => 'reuniao_relacionada',
+                        'value'   => 0,
+                        'compare' => '=',
+                    );
+                }
             }
 
             $videos_query = new WP_Query($video_args);
@@ -308,32 +333,47 @@ get_header();
             if ($videos_query->have_posts()) {
                 echo '<div class="row row-cols-1 row-cols-md-3 g-4">';
                 while ($videos_query->have_posts()) : $videos_query->the_post();
-                    $meeting_id = get_post_meta(get_the_ID(), 'reuniao_relacionada', true);
-                    $meeting    = $meeting_id ? get_post($meeting_id) : null;
-                    if ($selected_year && $meeting) {
-                        $m_date = agert_meta($meeting_id, 'data_hora');
-                        if ($m_date && (int) date('Y', strtotime($m_date)) !== $selected_year) {
-                            continue;
+                    $video_url   = get_post_meta(get_the_ID(), 'video_url', true);
+                    $duration    = (int) get_post_meta(get_the_ID(), 'duracao_segundos', true);
+                    $reuniao_id  = (int) get_post_meta(get_the_ID(), 'reuniao_relacionada', true);
+                    $title       = $reuniao_id ? get_the_title($reuniao_id) : get_the_title();
+                    $data_hora   = $reuniao_id ? agert_meta($reuniao_id, 'data_hora') : '';
+                    $thumb_url   = '';
+                    $platform    = agert_detectar_plataforma_video($video_url);
+                    if ($platform === 'youtube') {
+                        $yt_id = agert_extrair_youtube_id($video_url);
+                        if ($yt_id) {
+                            $thumb_url = agert_thumbnail_youtube($yt_id);
                         }
+                    } elseif ($platform === 'vimeo') {
+                        $thumb_url = agert_thumbnail_vimeo($video_url);
+                    } else {
+                        $custom_thumb_id = get_post_meta(get_the_ID(), 'thumbnail_personalizada', true);
+                        if ($custom_thumb_id) {
+                            $thumb_url = wp_get_attachment_url($custom_thumb_id);
+                        }
+                    }
+                    if (!$thumb_url) {
+                        $thumb_url = get_the_post_thumbnail_url(get_the_ID(), 'large');
                     }
                     echo '<div class="col">';
-                    get_template_part('parts/reunioes/card-video', null, array(
-                        'meeting' => $meeting,
-                        'video'   => get_post(),
-                    ));
-                    echo '</div>';
-                    $videos = get_post_meta(get_the_ID(), 'videos', true);
-                    if (is_array($videos)) {
-                        foreach ($videos as $video) {
-                            echo '<div class="col">';
-                            get_template_part('parts/reunioes/card-video', null, array(
-                                'meeting' => get_post(),
-                                'video'   => $video,
-                            ));
-                            echo '</div>';
-                        }
+                    echo '<div class="video-card">';
+                    echo '<div class="video-thumbnail">';
+                    if ($thumb_url) {
+                        echo '<img src="' . esc_url($thumb_url) . '" alt="' . esc_attr($title) . '">';
                     }
-
+                    echo '<div class="play-overlay">▶️</div>';
+                    if ($duration) {
+                        echo '<span class="video-duration">' . esc_html(agert_seconds_to_mmss($duration)) . '</span>';
+                    }
+                    echo '</div>';
+                    echo '<div class="video-info">';
+                    echo '<h3>' . esc_html($title) . '</h3>';
+                    if ($data_hora) {
+                        echo '<p>' . esc_html(date_i18n('d/m/Y', strtotime($data_hora))) . '</p>';
+                    }
+                    echo '<a href="' . esc_url($video_url) . '" target="_blank" class="btn-assistir">' . __('Assistir Vídeo', 'agert') . '</a>';
+                    echo '</div></div></div>';
                 endwhile;
                 echo '</div>';
 


### PR DESCRIPTION
## Summary
- Lista documentos a partir do CPT **Anexo** usando o arquivo associado e filtros por ano
- Exibe vídeos através de posts **reuniao_video** vinculados às reuniões, com miniaturas automáticas
- Ajusta utilitários para contar anexos e detectar vídeos existentes

## Testing
- `php -l inc/reunioes-helpers.php`
- `php -l page-acervo.php`


------
https://chatgpt.com/codex/tasks/task_e_68a744ced6d08326b2750d54e29a49ac