### PR TITLE
Corrige listagens de documentos e vídeos no acervo

### DIFF
--- a/inc/reunioes-helpers.php
+++ b/inc/reunioes-helpers.php
@@ -29,11 +29,17 @@ function agert_minutes_to_human(int $min): string {
 }
 
 /**
- * Converte segundos para mm:ss.
+ * Converte segundos para mm:ss ou hh:mm:ss quando necessário.
  */
 function agert_seconds_to_mmss(int $sec): string {
-    $minutes = floor($sec / 60);
+    $hours   = floor($sec / 3600);
+    $minutes = floor(($sec % 3600) / 60);
     $seconds = $sec % 60;
+
+    if ($hours > 0) {
+        return sprintf('%d:%02d:%02d', $hours, $minutes, $seconds);
+    }
+
     return sprintf('%02d:%02d', $minutes, $seconds);
 }
 
@@ -51,6 +57,50 @@ function agert_bytes_to_human(int $bytes): string {
 }
 
 /**
+ * Detecta a plataforma de vídeo a partir da URL.
+ */
+function agert_detectar_plataforma_video(string $url): string {
+    if (strpos($url, 'youtube.com') !== false || strpos($url, 'youtu.be') !== false) {
+        return 'youtube';
+    }
+    if (strpos($url, 'vimeo.com') !== false) {
+        return 'vimeo';
+    }
+    return 'outro';
+}
+
+/**
+ * Extrai o ID de um vídeo do YouTube.
+ */
+function agert_extrair_youtube_id(string $url): string {
+    if (preg_match('/(?:youtube\.com\/watch\?v=|youtu\.be\/)([^&\n?#]+)/', $url, $matches)) {
+        return $matches[1];
+    }
+    return '';
+}
+
+/**
+ * Retorna a URL da thumbnail do YouTube.
+ */
+function agert_thumbnail_youtube(string $id): string {
+    return "https://img.youtube.com/vi/{$id}/maxresdefault.jpg";
+}
+
+/**
+ * Obtém a thumbnail do Vimeo via oEmbed.
+ */
+function agert_thumbnail_vimeo(string $url): string {
+    $response = wp_remote_get('https://vimeo.com/api/oembed.json?url=' . rawurlencode($url));
+    if (!is_wp_error($response)) {
+        $data = json_decode(wp_remote_retrieve_body($response));
+        if (!empty($data->thumbnail_url)) {
+            return $data->thumbnail_url;
+        }
+    }
+    return '';
+}
+
+/**
  * Retorna o ano de uma string datetime.
  */
 function agert_get_year_from_datetime(string $dt): int {
@@ -62,8 +112,6 @@ function agert_get_year_from_datetime(string $dt): int {
  * Conta documentos relacionados à reunião.
  */
 function agert_count_documentos(int $post_id): int {
-    $docs = get_post_meta($post_id, 'anexos', true);
-
     $docs = get_posts(array(
         'post_type'      => 'anexo',
         'post_status'    => 'publish',
@@ -88,7 +136,58 @@ function agert_reuniao_has_video(int $post_id): bool {
         'fields'         => 'ids',
         'posts_per_page' => 1,
     ));
+
     return !empty($videos);
+}
+
+/**
+ * Obtém dados do primeiro vídeo associado à reunião.
+ *
+ * @param int $post_id ID da reunião.
+ * @return array{url:string, duration:int, thumb:string}|array
+ */
+function agert_get_reuniao_video_data(int $post_id): array {
+    $videos = get_posts(array(
+        'post_type'      => 'reuniao_video',
+        'post_status'    => 'publish',
+        'meta_key'       => 'reuniao_relacionada',
+        'meta_value'     => $post_id,
+        'posts_per_page' => 1,
+    ));
+
+    if (empty($videos)) {
+        return array();
+    }
+
+    $video    = $videos[0];
+    $url      = get_post_meta($video->ID, 'video_url', true);
+    $duration = (int) get_post_meta($video->ID, 'duracao_segundos', true);
+    $thumb    = '';
+
+    $platform = agert_detectar_plataforma_video($url);
+    if ($platform === 'youtube') {
+        $yt = agert_extrair_youtube_id($url);
+        if ($yt) {
+            $thumb = agert_thumbnail_youtube($yt);
+        }
+    } elseif ($platform === 'vimeo') {
+        $thumb = agert_thumbnail_vimeo($url);
+    } else {
+        $custom_thumb_id = get_post_meta($video->ID, 'thumbnail_personalizada', true);
+        if ($custom_thumb_id) {
+            $thumb = wp_get_attachment_url($custom_thumb_id);
+        }
+    }
+
+    if (!$thumb) {
+        $thumb = get_the_post_thumbnail_url($video->ID, 'large');
+    }
+
+    return array(
+        'url'      => $url,
+        'duration' => $duration,
+        'thumb'    => $thumb,
+    );
 }
 
 /**

--- a/page-acervo.php
+++ b/page-acervo.php
@@ -27,23 +27,6 @@ get_header();
         $selected_year = (int) $years[0];
     }
 
-    $meeting_ids_year = array();
-    if ($selected_year) {
-        $meeting_ids_year = get_posts(array(
-            'post_type'      => 'reuniao',
-            'post_status'    => 'publish',
-            'posts_per_page' => -1,
-            'fields'         => 'ids',
-            'meta_query'     => array(
-                array(
-                    'key'     => 'data_hora',
-                    'value'   => array($selected_year . '-01-01', $selected_year . '-12-31 23:59:59'),
-                    'compare' => 'BETWEEN',
-                    'type'    => 'DATETIME',
-                ),
-            ),
-        ));
-    }
     if ($years) :
     ?>
         <div class="d-flex justify-content-center gap-2 mb-4" aria-label="<?php esc_attr_e('Filtrar por ano', 'agert'); ?>">
@@ -181,19 +164,30 @@ get_header();
             $doc_search = isset($_GET['doc_q']) ? sanitize_text_field($_GET['doc_q']) : '';
             $doc_args   = array(
                 'post_type'      => 'anexo',
+                'post_status'    => 'publish',
                 'posts_per_page' => 9,
                 'paged'          => $docs_paged,
-                'post_status'    => 'publish',
                 'orderby'        => 'date',
                 'order'          => 'DESC',
                 's'              => $doc_search,
+                'meta_query'     => array(
+                    'relation' => 'AND',
+                    array(
+                        'key'     => '_arquivo_id',
+                        'compare' => 'EXISTS',
+                    ),
+                    array(
+                        'key'     => '_reuniao_id',
+                        'compare' => 'EXISTS',
+                    ),
+                ),
             );
 
-            if (!empty($meeting_ids_year)) {
-                $doc_args['meta_query'][] = array(
-                    'key'     => '_reuniao_id',
-                    'value'   => $meeting_ids_year,
-                    'compare' => 'IN',
+            if ($selected_year) {
+                $doc_args['date_query'] = array(
+                    array(
+                        'year' => $selected_year,
+                    ),
                 );
             }
 
@@ -217,23 +211,52 @@ get_header();
             <?php
 
             if ($attachments->have_posts()) {
-                echo '<div class="document-list">';
+                echo '<div class="documento-list">';
                 while ($attachments->have_posts()) : $attachments->the_post();
-                    $reuniao_id = get_post_meta(get_the_ID(), '_reuniao_id', true);
-                    $meeting    = $reuniao_id ? get_post($reuniao_id) : null;
-                    if ($selected_year && $meeting) {
-                        $m_date = agert_meta($meeting->ID, 'data_hora');
-                        if ($m_date && (int) date('Y', strtotime($m_date)) !== $selected_year) {
-                            continue;
-                        }
+                    $arquivo_id  = (int) get_post_meta(get_the_ID(), '_arquivo_id', true);
+                    $reuniao_id  = (int) get_post_meta(get_the_ID(), '_reuniao_id', true);
+                    if (!$arquivo_id) { continue; }
+
+                    $file_url   = wp_get_attachment_url($arquivo_id);
+                    $file_path  = get_attached_file($arquivo_id);
+                    $file_size  = ($file_path && file_exists($file_path)) ? size_format(filesize($file_path)) : '';
+                    $doc_title  = get_the_title();
+                    $doc_type   = strtok($doc_title, ' ');
+                    $excerpt    = get_the_excerpt();
+
+                    $meeting_link = $reuniao_id ? get_permalink($reuniao_id) : '';
+                    $meeting_dt   = $reuniao_id ? agert_meta($reuniao_id, 'data_hora', '') : '';
+                    $meeting_date = $meeting_dt ? date_i18n('d/m/Y', strtotime($meeting_dt)) : '';
+
+                    echo '<div class="documento-item d-flex flex-column flex-lg-row align-items-lg-center justify-content-between border rounded p-3 mb-3">';
+
+                    echo '<div class="flex-grow-1 me-lg-3">';
+                    echo '<div class="d-flex align-items-center gap-2 mb-1">';
+                    if ($doc_type) {
+                        echo '<span class="badge bg-light text-dark">' . esc_html($doc_type) . '</span>';
                     }
-                    $arquivo_id = (int) get_post_meta(get_the_ID(), '_arquivo_id', true);
-                    $doc        = array(
-                        'rotulo'      => get_the_title(),
-                        'resumo'      => get_the_excerpt(),
-                        'arquivo_url' => $arquivo_id ? wp_get_attachment_url($arquivo_id) : '',
-                    );
-                    get_template_part('parts/reunioes/row-documento', null, array('doc' => $doc, 'meeting' => $meeting));
+                    echo '<i class="bi bi-file-earmark-pdf text-danger"></i>';
+                    if ($meeting_date) {
+                        echo '<span class="text-muted"><i class="bi bi-calendar3 me-1"></i>' . esc_html($meeting_date) . '</span>';
+                    }
+                    echo '</div>';
+                    echo '<h3 class="h6 mb-1">' . esc_html($doc_title) . '</h3>';
+                    if ($excerpt) {
+                        echo '<p class="mb-2 text-muted">' . esc_html($excerpt) . '</p>';
+                    }
+                    if ($file_size) {
+                        echo '<small class="text-muted">' . sprintf(__('Tamanho: %s', 'agert'), esc_html($file_size)) . '</small>';
+                    }
+                    echo '</div>';
+
+                    echo '<div class="d-flex gap-2 mt-3 mt-lg-0">';
+                    if ($meeting_link) {
+                        echo '<a href="' . esc_url($meeting_link) . '" class="btn btn-outline-secondary btn-sm"><i class="bi bi-eye"></i> ' . __('Ver Reunião', 'agert') . '</a>';
+                    }
+                    echo '<a href="' . esc_url($file_url) . '" class="btn btn-outline-secondary btn-sm" download><i class="bi bi-download"></i> ' . __('Download', 'agert') . '</a>';
+                    echo '</div>';
+
+                    echo '</div>';
                 endwhile;
                 echo '</div>';
 
@@ -276,14 +299,43 @@ get_header();
                 's'              => $video_search,
                 'orderby'        => 'date',
                 'order'          => 'DESC',
+                'meta_query'     => array(
+                    array(
+                        'key'     => 'video_url',
+                        'value'   => '',
+                        'compare' => '!=',
+                    ),
+                ),
             );
 
-            if (!empty($meeting_ids_year)) {
-                $video_args['meta_query'][] = array(
-                    'key'     => 'reuniao_relacionada',
-                    'value'   => $meeting_ids_year,
-                    'compare' => 'IN',
-                );
+            if ($selected_year) {
+                $reunioes_ids = get_posts(array(
+                    'post_type'      => 'reuniao',
+                    'post_status'    => 'publish',
+                    'fields'         => 'ids',
+                    'posts_per_page' => -1,
+                    'meta_query'     => array(
+                        array(
+                            'key'     => 'data_hora',
+                            'value'   => array($selected_year . '-01-01', $selected_year . '-12-31 23:59:59'),
+                            'compare' => 'BETWEEN',
+                            'type'    => 'DATETIME',
+                        ),
+                    ),
+                ));
+                if ($reunioes_ids) {
+                    $video_args['meta_query'][] = array(
+                        'key'     => 'reuniao_relacionada',
+                        'value'   => $reunioes_ids,
+                        'compare' => 'IN',
+                    );
+                } else {
+                    $video_args['meta_query'][] = array(
+                        'key'     => 'reuniao_relacionada',
+                        'value'   => 0,
+                        'compare' => '=',
+                    );
+                }
             }
 
             $videos_query = new WP_Query($video_args);
@@ -308,32 +360,47 @@ get_header();
             if ($videos_query->have_posts()) {
                 echo '<div class="row row-cols-1 row-cols-md-3 g-4">';
                 while ($videos_query->have_posts()) : $videos_query->the_post();
-                    $meeting_id = get_post_meta(get_the_ID(), 'reuniao_relacionada', true);
-                    $meeting    = $meeting_id ? get_post($meeting_id) : null;
-                    if ($selected_year && $meeting) {
-                        $m_date = agert_meta($meeting_id, 'data_hora');
-                        if ($m_date && (int) date('Y', strtotime($m_date)) !== $selected_year) {
-                            continue;
+                    $video_url   = get_post_meta(get_the_ID(), 'video_url', true);
+                    $duration    = (int) get_post_meta(get_the_ID(), 'duracao_segundos', true);
+                    $reuniao_id  = (int) get_post_meta(get_the_ID(), 'reuniao_relacionada', true);
+                    $title       = $reuniao_id ? get_the_title($reuniao_id) : get_the_title();
+                    $data_hora   = $reuniao_id ? agert_meta($reuniao_id, 'data_hora') : '';
+                    $thumb_url   = '';
+                    $platform    = agert_detectar_plataforma_video($video_url);
+                    if ($platform === 'youtube') {
+                        $yt_id = agert_extrair_youtube_id($video_url);
+                        if ($yt_id) {
+                            $thumb_url = agert_thumbnail_youtube($yt_id);
                         }
+                    } elseif ($platform === 'vimeo') {
+                        $thumb_url = agert_thumbnail_vimeo($video_url);
+                    } else {
+                        $custom_thumb_id = get_post_meta(get_the_ID(), 'thumbnail_personalizada', true);
+                        if ($custom_thumb_id) {
+                            $thumb_url = wp_get_attachment_url($custom_thumb_id);
+                        }
+                    }
+                    if (!$thumb_url) {
+                        $thumb_url = get_the_post_thumbnail_url(get_the_ID(), 'large');
                     }
                     echo '<div class="col">';
-                    get_template_part('parts/reunioes/card-video', null, array(
-                        'meeting' => $meeting,
-                        'video'   => get_post(),
-                    ));
-                    echo '</div>';
-                    $videos = get_post_meta(get_the_ID(), 'videos', true);
-                    if (is_array($videos)) {
-                        foreach ($videos as $video) {
-                            echo '<div class="col">';
-                            get_template_part('parts/reunioes/card-video', null, array(
-                                'meeting' => get_post(),
-                                'video'   => $video,
-                            ));
-                            echo '</div>';
-                        }
+                    echo '<div class="video-card">';
+                    echo '<div class="video-thumbnail">';
+                    if ($thumb_url) {
+                        echo '<img src="' . esc_url($thumb_url) . '" alt="' . esc_attr($title) . '">';
                     }
-
+                    echo '<div class="play-overlay">▶️</div>';
+                    if ($duration) {
+                        echo '<span class="video-duration">' . esc_html(agert_seconds_to_mmss($duration)) . '</span>';
+                    }
+                    echo '</div>';
+                    echo '<div class="video-info">';
+                    echo '<h3>' . esc_html($title) . '</h3>';
+                    if ($data_hora) {
+                        echo '<p>' . esc_html(date_i18n('d/m/Y', strtotime($data_hora))) . '</p>';
+                    }
+                    echo '<a href="' . esc_url($video_url) . '" target="_blank" class="btn-assistir">' . __('Assistir Vídeo', 'agert') . '</a>';
+                    echo '</div></div></div>';
                 endwhile;
                 echo '</div>';
 

--- a/parts/reunioes/card-reuniao.php
+++ b/parts/reunioes/card-reuniao.php
@@ -9,27 +9,32 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-$post_id = get_the_ID();
-$thumb   = get_the_post_thumbnail($post_id, 'large', array('class' => 'thumb-16x9 w-100', 'alt' => esc_attr(get_the_title())));
-$duracao = agert_meta($post_id, 'duracao');
-$tipo    = '';
-$terms   = get_the_terms($post_id, 'tipo_reuniao');
+$post_id     = get_the_ID();
+$video_data  = agert_get_reuniao_video_data($post_id);
+$thumb_url   = $video_data['thumb'] ?? '';
+$video_dur   = $video_data['duration'] ?? 0;
+$tipo        = '';
+$terms       = get_the_terms($post_id, 'tipo_reuniao');
 if ($terms && !is_wp_error($terms)) {
     $tipo = $terms[0]->name;
 } else {
     $tipo = agert_meta($post_id, 'tipo_reuniao');
 }
-$video   = agert_reuniao_has_video($post_id);
-$doc_qtd = agert_count_documentos($post_id);
+$video     = !empty($video_data);
+$doc_qtd   = agert_count_documentos($post_id);
 $data_hora = agert_meta($post_id, 'data_hora');
 ?>
 <div class="card card-soft h-100">
     <div class="position-relative">
-        <?php if ($thumb) : ?>
-            <?php echo $thumb; ?>
+        <?php if ($thumb_url) : ?>
+            <img src="<?php echo esc_url($thumb_url); ?>" class="thumb-16x9 w-100" alt="<?php echo esc_attr(get_the_title()); ?>">
+        <?php else : ?>
+            <div class="thumb-16x9 w-100 d-flex align-items-center justify-content-center bg-light text-muted">
+                <?php _e('Não há imagens/vídeo', 'agert'); ?>
+            </div>
         <?php endif; ?>
-        <?php if ($duracao) : ?>
-            <span class="duration-badge"><?php echo esc_html(agert_seconds_to_mmss((int) $duracao * 60)); ?></span>
+        <?php if ($video_dur) : ?>
+            <span class="duration-badge"><?php echo esc_html(agert_seconds_to_mmss((int) $video_dur)); ?></span>
         <?php endif; ?>
         <?php if ($tipo) : ?>
             <span class="badge-chip position-absolute m-2"><?php echo esc_html($tipo); ?></span>


### PR DESCRIPTION
## Summary
- Estiliza listagem de documentos com cartão horizontal, exibindo tipo, data, resumo, tamanho e ações de ver reunião ou baixar
- Lista vídeos a partir de posts reuniao_video, gerando miniaturas e detalhes de reunião
- Mostra thumbnail do vídeo nos cards de reuniões, exibindo aviso quando não há mídia

## Testing
- `php -l inc/reunioes-helpers.php`
- `php -l parts/reunioes/card-reuniao.php`
- `php -l page-acervo.php`


------
https://chatgpt.com/codex/tasks/task_e_68a744ced6d08326b2750d54e29a49ac