### PR TITLE
Implementa filtro mensal e layout em tabela para Agenda Fiscal

### DIFF
--- a/archive-agenda_fiscal.php
+++ b/archive-agenda_fiscal.php
@@ -20,30 +20,41 @@ $query = new WP_Query($args);
     <div class="container">
         <h1 class="mb-4"><?php _e('Planejamento Fiscal', 'agert'); ?></h1>
         <?php if ($query->have_posts()) : ?>
-            <div class="row row-cols-1 row-cols-md-2 g-4">
-                <?php while ($query->have_posts()) : $query->the_post(); ?>
-                    <div class="col">
-                        <div class="card agenda-card h-100 shadow-sm">
-                            <div class="card-body">
-                                <div class="d-flex justify-content-between align-items-center mb-2">
-                                    <span class="badge text-white"><?php echo esc_html(get_post_meta(get_the_ID(), '_modalidade', true)); ?></span>
-                                    <small class="text-muted">
-                                        <?php echo esc_html(get_post_meta(get_the_ID(), '_inicio', true)); ?> - <?php echo esc_html(get_post_meta(get_the_ID(), '_fim', true)); ?>
-                                    </small>
-                                </div>
-                                <h5 class="card-title mb-2"><?php echo esc_html(get_post_meta(get_the_ID(), '_atividade', true)); ?></h5>
-                                <p class="card-text mb-1"><strong><?php _e('Prestador:', 'agert'); ?></strong> <?php echo esc_html(get_post_meta(get_the_ID(), '_prestador', true)); ?></p>
-                                <p class="card-text mb-1"><strong><?php _e('Responsável:', 'agert'); ?></strong> <?php echo esc_html(get_post_meta(get_the_ID(), '_responsavel', true)); ?></p>
-                                <p class="card-text"><strong><?php _e('Objetivo:', 'agert'); ?></strong> <?php echo esc_html(get_post_meta(get_the_ID(), '_objetivo', true)); ?></p>
-                                <?php if ($aid = get_post_meta(get_the_ID(), '_arquivo_id', true)) : ?>
-                                    <a href="<?php echo esc_url(wp_get_attachment_url($aid)); ?>" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener">
-                                        <?php _e('Baixar anexo', 'agert'); ?>
-                                    </a>
-                                <?php endif; ?>
-                            </div>
-                        </div>
-                    </div>
-                <?php endwhile; ?>
+            <div class="table-responsive">
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th><?php _e('Início', 'agert'); ?></th>
+                            <th><?php _e('Fim', 'agert'); ?></th>
+                            <th><?php _e('Prestador de Serviço', 'agert'); ?></th>
+                            <th><?php _e('Atividade/Local', 'agert'); ?></th>
+                            <th><?php _e('Modalidade', 'agert'); ?></th>
+                            <th><?php _e('Responsável', 'agert'); ?></th>
+                            <th><?php _e('Objetivo', 'agert'); ?></th>
+                            <th><?php _e('Anexo', 'agert'); ?></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php while ($query->have_posts()) : $query->the_post(); ?>
+                            <tr>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_inicio', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_fim', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_prestador', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_atividade', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_modalidade', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_responsavel', true)); ?></td>
+                                <td><?php echo esc_html(get_post_meta(get_the_ID(), '_objetivo', true)); ?></td>
+                                <td>
+                                    <?php if ($aid = get_post_meta(get_the_ID(), '_arquivo_id', true)) : ?>
+                                        <a href="<?php echo esc_url(wp_get_attachment_url($aid)); ?>" class="btn btn-sm btn-outline-primary" target="_blank" rel="noopener">
+                                            <?php _e('Baixar anexo', 'agert'); ?>
+                                        </a>
+                                    <?php endif; ?>
+                                </td>
+                            </tr>
+                        <?php endwhile; ?>
+                    </tbody>
+                </table>
             </div>
         <?php else : ?>
             <p><?php _e('Nenhuma programação encontrada.', 'agert'); ?></p>

--- a/assets/js/agenda-fiscal.js
+++ b/assets/js/agenda-fiscal.js
@@ -3,17 +3,19 @@
 
 document.addEventListener('DOMContentLoaded', function () {
     var calendarEl = document.getElementById('agenda-fiscal-calendar');
-
     var dateFilter = document.getElementById('agenda-fiscal-date-filter');
+    var goBtn = document.getElementById('agenda-fiscal-go-btn');
 
     if (!calendarEl || typeof FullCalendar === 'undefined' || typeof agertAgendaFiscal === 'undefined') {
         return;
     }
 
+    var allEvents = agertAgendaFiscal.events || [];
+
     var calendar = new FullCalendar.Calendar(calendarEl, {
         initialView: 'dayGridMonth',
         locale: 'pt-br',
-        events: agertAgendaFiscal.events || [],
+        events: allEvents,
         eventClick: function(info) {
             if (info.event.url) {
                 window.location.href = info.event.url;
@@ -24,26 +26,26 @@ document.addEventListener('DOMContentLoaded', function () {
 
     calendar.render();
 
-    if (dateFilter) {
-        dateFilter.addEventListener('change', function () {
+    if (dateFilter && goBtn) {
+        goBtn.addEventListener('click', function () {
             var selected = dateFilter.value;
             calendar.removeAllEvents();
             if (selected) {
-                var d = new Date(selected);
-                d.setHours(0, 0, 0, 0);
+                var parts = selected.split('-');
+                var year = parseInt(parts[0], 10);
+                var month = parseInt(parts[1], 10) - 1; // zero-based
+                var startOfMonth = new Date(year, month, 1);
+                var endOfMonth = new Date(year, month + 1, 0);
                 var filtered = allEvents.filter(function (ev) {
                     var start = new Date(ev.start);
                     var end = ev.end ? new Date(ev.end) : start;
-                    start.setHours(0, 0, 0, 0);
-                    end.setHours(0, 0, 0, 0);
-                    return start <= d && end >= d;
+                    return start <= endOfMonth && end >= startOfMonth;
                 });
                 calendar.addEventSource(filtered);
-                calendar.gotoDate(selected);
+                calendar.gotoDate(startOfMonth);
             } else {
                 calendar.addEventSource(allEvents);
             }
         });
     }
-
 });

--- a/front-page.php
+++ b/front-page.php
@@ -219,9 +219,14 @@ get_header(); ?>
         <div class="row mb-3">
             <div class="col-md-4 ms-auto">
                 <label for="agenda-fiscal-date-filter" class="form-label mb-0">
-                    <?php _e('Filtrar por data', 'agert'); ?>
+                    <?php _e('Filtrar por mês/ano', 'agert'); ?>
                 </label>
-                <input type="date" id="agenda-fiscal-date-filter" class="form-control">
+                <div class="input-group">
+                    <input type="month" id="agenda-fiscal-date-filter" class="form-control">
+                    <button class="btn btn-outline-secondary" id="agenda-fiscal-go-btn">
+                        <?php _e('Ir', 'agert'); ?>
+                    </button>
+                </div>
             </div>
         </div>
         <div id="agenda-fiscal-calendar"></div>


### PR DESCRIPTION
## Summary
- permite filtrar Agenda Fiscal por mês/ano com botão "Ir"
- substitui cards por tabela na página de Agenda Fiscal
- corrige script do calendário para suportar novo filtro

## Testing
- `php -l front-page.php`
- `php -l archive-agenda_fiscal.php`
- `node --check assets/js/agenda-fiscal.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a878bc65dc83268d29b1dcec7ef190