### PR TITLE
Add filters and pagination to Agenda Fiscal archive

### DIFF
--- a/archive-agenda_fiscal.php
+++ b/archive-agenda_fiscal.php
@@ -7,18 +7,69 @@
 
 get_header();
 
+$prestador  = isset($_GET['prestador']) ? sanitize_text_field($_GET['prestador']) : '';
+$modalidade = isset($_GET['modalidade']) ? sanitize_text_field($_GET['modalidade']) : '';
+$inicio     = isset($_GET['inicio']) ? sanitize_text_field($_GET['inicio']) : '';
+
+$meta_query = array();
+
+if ($prestador) {
+    $meta_query[] = array(
+        'key'     => '_prestador',
+        'value'   => $prestador,
+        'compare' => 'LIKE',
+    );
+}
+
+if ($modalidade) {
+    $meta_query[] = array(
+        'key'     => '_modalidade',
+        'value'   => $modalidade,
+        'compare' => 'LIKE',
+    );
+}
+
+if ($inicio) {
+    $meta_query[] = array(
+        'key'   => '_inicio',
+        'value' => $inicio,
+    );
+}
+
 $args = array(
     'post_type'      => 'agenda_fiscal',
-    'posts_per_page' => -1,
+    'posts_per_page' => 20,
+    'paged'          => get_query_var('paged', 1),
     'meta_key'       => '_inicio',
     'orderby'        => 'meta_value',
     'order'          => 'ASC',
 );
+
+if (!empty($meta_query)) {
+    $args['meta_query'] = $meta_query;
+}
+
 $query = new WP_Query($args);
 ?>
 <section class="py-5">
     <div class="container">
         <h1 class="mb-4"><?php _e('Planejamento Fiscal', 'agert'); ?></h1>
+        <form method="get" class="agenda-filters mb-4">
+            <div class="row g-2">
+                <div class="col-md-3">
+                    <input type="text" name="prestador" class="form-control" placeholder="<?php _e('Prestador', 'agert'); ?>" value="<?php echo esc_attr($prestador); ?>">
+                </div>
+                <div class="col-md-3">
+                    <input type="text" name="modalidade" class="form-control" placeholder="<?php _e('Modalidade', 'agert'); ?>" value="<?php echo esc_attr($modalidade); ?>">
+                </div>
+                <div class="col-md-3">
+                    <input type="date" name="inicio" class="form-control" value="<?php echo esc_attr($inicio); ?>">
+                </div>
+                <div class="col-md-3">
+                    <button type="submit" class="btn btn-primary w-100"><?php _e('Filtrar', 'agert'); ?></button>
+                </div>
+            </div>
+        </form>
         <?php if ($query->have_posts()) : ?>
             <div class="table-responsive">
                 <table class="table">
@@ -59,6 +110,17 @@ $query = new WP_Query($args);
         <?php else : ?>
             <p><?php _e('Nenhuma programação encontrada.', 'agert'); ?></p>
         <?php endif; wp_reset_postdata(); ?>
+        <?php
+        $pagination = paginate_links(array(
+            'total'   => $query->max_num_pages,
+            'current' => max(1, get_query_var('paged', 1)),
+            'add_args' => array_filter(compact('prestador', 'modalidade', 'inicio')),
+        ));
+        if ($pagination) : ?>
+            <nav class="agenda-pagination mt-4">
+                <?php echo $pagination; ?>
+            </nav>
+        <?php endif; ?>
     </div>
 </section>
 <?php

--- a/assets/css/agenda-fiscal.css
+++ b/assets/css/agenda-fiscal.css
@@ -5,3 +5,8 @@
 .agenda-card .badge { background: var(--brand); }
 
 .agenda-card small { color: var(--muted); }
+
+.agenda-filters { border: 1px solid var(--line); border-radius: 8px; padding: 1rem; background: var(--bg); }
+
+.agenda-pagination { display: flex; justify-content: center; }
+.agenda-pagination .page-numbers { margin: 0 .25rem; }


### PR DESCRIPTION
## Summary
- enable filtering by prestador, modalidade, and início using meta queries
- paginate Agenda Fiscal posts and render navigation links
- add filter form and styling for filters and pagination

## Testing
- `php -l archive-agenda_fiscal.php`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8894237648326ba13b207f32715ae