### PR TITLE
Adjust brand logo sizing and containment

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -23,7 +23,13 @@
 
 /* Marca (logo + textos) */
 .brand { display:flex; align-items:center; gap:12px; text-decoration:none; color:inherit; }
-.brand__logo img { height:34px; width:auto; display:block; }
+.brand__logo img {
+  width:34px;
+  height:34px;
+  object-fit:contain;
+  display:inline-block;
+  overflow:hidden;
+}
 .brand__logo--placeholder { width:34px; height:34px; border-radius:8px; background:#23243a; display:inline-block; }
 .brand__text { display:flex; flex-direction:column; line-height:1.1; }
 .brand__title { font-size:20px; font-weight:700; color:#ffffff; }


### PR DESCRIPTION
## Summary
- Ensure `.brand__logo img` is constrained to 34x34px with `object-fit: contain`
- Prevent logo overflow with `display: inline-block` and `overflow: hidden`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac48e552cc8326995d40aabaa8f4c7