### PR TITLE
Remove link from empty meetings state

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -183,10 +183,6 @@ get_header(); ?>
                             <h5><?php _e('Nenhuma reunião encontrada', 'agert'); ?></h5>
                             <p class="text-muted"><?php _e('Ainda não há reuniões cadastradas no sistema.', 'agert'); ?></p>
                             <?php if (agert_user_can_create_posts()) : ?>
-                                <a href="<?php echo esc_url(agert_get_page_link('acervo')); ?>" class="btn btn-primary">
-                                    <i class="bi bi-plus-circle me-2"></i>
-                                    <?php _e('Criar primeira reunião', 'agert'); ?>
-                                </a>
                             <?php endif; ?>
                         </div>
                     </div>


### PR DESCRIPTION
## Summary
- Remove call-to-action link from empty meetings card so only message remains

## Testing
- `php -l front-page.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac48f356208326b80a4b10a5d39a55