### PR TITLE
Remove meeting selection from participant creation

### DIFF
--- a/inc/post-types.php
+++ b/inc/post-types.php
@@ -329,16 +329,6 @@ function agert_participante_meta_box_callback($post) {
     $nome_participante = get_post_meta($post->ID, '_nome_participante', true);
     $cargo = get_post_meta($post->ID, '_cargo', true);
     $email = get_post_meta($post->ID, '_email', true);
-    $reuniao_id = get_post_meta($post->ID, '_reuniao_id', true);
-    
-    // Buscar reuniões para select
-    $reunioes = get_posts(array(
-        'post_type' => 'reuniao',
-        'posts_per_page' => -1,
-        'post_status' => 'publish',
-        'orderby' => 'date',
-        'order' => 'DESC'
-    ));
     ?>
     <table class="form-table">
         <tr>
@@ -352,20 +342,6 @@ function agert_participante_meta_box_callback($post) {
         <tr>
             <th><label for="email"><?php _e('E-mail', 'agert'); ?></label></th>
             <td><input type="email" id="email" name="email" value="<?php echo esc_attr($email); ?>" class="regular-text" /></td>
-        </tr>
-        <tr>
-            <th><label for="reuniao_id"><?php _e('Reunião', 'agert'); ?></label></th>
-            <td>
-                <select id="reuniao_id" name="reuniao_id" class="regular-text">
-                    <option value=""><?php _e('Selecione uma reunião', 'agert'); ?></option>
-                    <?php foreach ($reunioes as $reuniao) : ?>
-                        <option value="<?php echo $reuniao->ID; ?>" <?php selected($reuniao_id, $reuniao->ID); ?>>
-                            <?php echo esc_html($reuniao->post_title); ?>
-                        </option>
-                    <?php endforeach; ?>
-                </select>
-            </td>
-        </tr>
     </table>
     <?php
 }
@@ -556,9 +532,6 @@ function agert_save_meta_boxes($post_id) {
         }
         if (isset($_POST['email'])) {
             update_post_meta($post_id, '_email', sanitize_email($_POST['email']));
-        }
-        if (isset($_POST['reuniao_id'])) {
-            update_post_meta($post_id, '_reuniao_id', intval($_POST['reuniao_id']));
         }
     }
 

--- a/page-participantes.php
+++ b/page-participantes.php
@@ -12,9 +12,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_participant_no
         $nome       = agert_sanitize_text($_POST['nome_participante'] ?? '');
         $cargo      = agert_sanitize_text($_POST['cargo'] ?? '');
         $email      = sanitize_email($_POST['email'] ?? '');
-        $reuniao_id = intval($_POST['reuniao_id'] ?? 0);
 
-        if ($nome && $email && $reuniao_id) {
+        if ($nome && $email) {
             $participant_id = wp_insert_post(array(
                 'post_title'  => $nome,
                 'post_type'   => 'participante',
@@ -25,7 +24,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_participant_no
                 update_post_meta($participant_id, '_nome_participante', $nome);
                 update_post_meta($participant_id, '_cargo', $cargo);
                 update_post_meta($participant_id, '_email', $email);
-                update_post_meta($participant_id, '_reuniao_id', $reuniao_id);
                 wp_redirect(esc_url(add_query_arg('status', 'participante_created', esc_url(get_permalink()))));
                 exit;
             }
@@ -72,20 +70,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_participant_no
                         <th><?php _e('Nome', 'agert'); ?></th>
                         <th><?php _e('Cargo', 'agert'); ?></th>
                         <th><?php _e('E-mail', 'agert'); ?></th>
-                        <th><?php _e('Reunião', 'agert'); ?></th>
                     </tr>
                 </thead>
                 <tbody>
                     <?php while ($participants->have_posts()) : $participants->the_post();
-                        $reuniao_id = get_post_meta(get_the_ID(), '_reuniao_id', true);
-                        $cargo      = get_post_meta(get_the_ID(), '_cargo', true);
-                        $email      = get_post_meta(get_the_ID(), '_email', true);
+                        $cargo = get_post_meta(get_the_ID(), '_cargo', true);
+                        $email = get_post_meta(get_the_ID(), '_email', true);
                     ?>
                         <tr>
                             <td><?php the_title(); ?></td>
                             <td><?php echo esc_html($cargo); ?></td>
                             <td><?php echo esc_html($email); ?></td>
-                            <td><?php echo $reuniao_id ? esc_html(get_the_title($reuniao_id)) : '-'; ?></td>
                         </tr>
                     <?php endwhile; ?>
                 </tbody>
@@ -122,12 +117,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && isset($_POST['create_participant_no
                     <div class="mb-3">
                         <label for="email" class="form-label"><?php _e('E-mail', 'agert'); ?></label>
                         <input type="email" id="email" name="email" class="form-control" required>
-                    </div>
-                    <div class="mb-3">
-                        <label for="reuniao_id" class="form-label"><?php _e('Reunião', 'agert'); ?></label>
-                        <select id="reuniao_id" name="reuniao_id" class="form-select" required data-load-meetings>
-                            <option value=""><?php _e('Selecione uma reunião', 'agert'); ?></option>
-                        </select>
                     </div>
                 </div>
                 <div class="modal-footer">


### PR DESCRIPTION
## Summary
- drop meeting requirement when creating participants
- remove admin metabox field for meeting association

## Testing
- `php -l page-participantes.php`
- `php -l inc/post-types.php`


------
https://chatgpt.com/codex/tasks/task_e_68ac5c08bb548326b563122dbe61740a