### PR TITLE
chore: align theme palette with logo colors

### DIFF
--- a/assets/css/header.css
+++ b/assets/css/header.css
@@ -7,9 +7,9 @@
 
 /* Barra */
 .site-header__bar {
-  background:#060312; /* tom quase preto */
-  color:#e8e9ee;
-  border-bottom:1px solid rgba(255,255,255,.06);
+  background:var(--brand); /* azul principal */
+  color:#ffffff;
+  border-bottom:1px solid rgba(0,0,0,.06);
 }
 .site-header__bar .container {
   max-width:1200px;
@@ -30,10 +30,10 @@
   display:inline-block;
   overflow:hidden;
 }
-.brand__logo--placeholder { width:34px; height:34px; border-radius:8px; background:#23243a; display:inline-block; }
+.brand__logo--placeholder { width:34px; height:34px; border-radius:8px; background:var(--brand-700); display:inline-block; }
 .brand__text { display:flex; flex-direction:column; line-height:1.1; }
 .brand__title { font-size:20px; font-weight:700; color:#ffffff; }
-.brand__tagline { font-size:12px; color:#bdc0cf; }
+.brand__tagline { font-size:12px; color:var(--highlight); }
 
 /* Menu */
 .main-nav .menu { list-style:none; display:flex; gap:28px; margin:0; padding:0; align-items:center; }
@@ -42,7 +42,7 @@
   display:inline-flex; align-items:center;
   padding:8px 14px;
   border-radius:10px;
-  color:#e8e9ee;
+  color:#ffffff;
   text-decoration:none;
   font-weight:500;
   transition:background .2s ease, color .2s ease, box-shadow .2s ease;
@@ -55,8 +55,8 @@
 .main-nav .menu .current-menu-ancestor > a,
 .main-nav .menu a[aria-current="page"],
 .main-nav .menu .current-page-ancestor > a {
-  background: #ffffff;
-  color: var(--brand, #0B0A14);
+  background: var(--highlight);
+  color: var(--brand);
   border-radius: 12px;
   padding: .4rem .75rem;
   box-shadow: 0 1px 0 rgba(0,0,0,.08);

--- a/assets/css/ui-tokens.css
+++ b/assets/css/ui-tokens.css
@@ -1,17 +1,18 @@
 :root{
-  --brand:#0B0A14;        /* preto do tema */
-  --brand-600:#0B0A14;
-  --brand-700:#151320;    /* hover */
-  --ink:#111827; 
-  --muted:#6B7280; 
-  --line:#EEF0F3; 
-  --bg:#F7F8FA; 
+  --brand:#395daa;        /* azul principal */
+  --brand-600:#395daa;
+  --brand-700:#2d4a88;    /* hover */
+  --highlight:#f2bc26;    /* amarelo */
+  --ink:#111827;
+  --muted:#6B7280;
+  --line:#EEF0F3;
+  --bg:#F7F8FA;
   --white:#fff;
-  --success:#16a34a; 
-  --warning:#f59e0b; 
+  --success:#16a34a;
+  --warning:#f59e0b;
   --danger:#ef4444;
-  --radius-card:16px; 
-  --radius-chip:999px; 
+  --radius-card:16px;
+  --radius-chip:999px;
   --shadow:0 6px 18px rgba(0,0,0,.06);
 }
 

--- a/style.css
+++ b/style.css
@@ -14,11 +14,11 @@ Requires PHP: 7.4
 
 /* ===== VARIÁVEIS CSS BASEADAS NO DESIGN SYSTEM ORIGINAL ===== */
 :root {
-  /* Cores principais (baseadas no design original) */
-  --agert-primary: #030213;
-  --agert-primary-rgb: 3, 2, 19;
+  /* Paleta principal baseada nas cores da logo */
+  --agert-primary: #395daa; /* azul */
+  --agert-primary-rgb: 57, 93, 170;
   --agert-primary-foreground: #ffffff;
-  --agert-secondary: #ececf0;
+  --agert-secondary: #f2bc26; /* amarelo */
   --agert-secondary-foreground: #030213;
   --agert-background: #ffffff;
   --agert-foreground: #212529;


### PR DESCRIPTION
## Summary
- use logo blue and yellow as primary palette
- refresh header styles to leverage new brand tokens

## Testing
- `npm test` (fails: could not read package.json)
- `php -l header.php`
- `php -l functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad957b5c88326839f3e0a5e09b4b2